### PR TITLE
added redirect link to stack overflow

### DIFF
--- a/stackoverflow.html
+++ b/stackoverflow.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0;URL='https://stackoverflow.com/users/7219194/konnovdev?tab=profile'"/>
+  <title>konnovdev stackoverflow profile</title>
+</head>
+</html>


### PR DESCRIPTION
stackoverflow doesn't have cutom profile links like facebook, the profile id is always a set of random numbers. So I decided to use my domain to redirect to my profile